### PR TITLE
Added a bunch of other blacklisted textures.

### DIFF
--- a/blacklisted_textures.json
+++ b/blacklisted_textures.json
@@ -27,7 +27,14 @@
     "entity/phantom_eyes.png",
     "block/water_overlay.png",
     "entity/end_portal.png",
-    "item/leather_chestplate_overlay.png"
+    "item/leather_chestplate_overlay.png",
+    "block/debug.png",
+    "block/debug2.png",
+    "environment/end_sky.png",
+    "gui/title/mojangstudios.png",
+    "misc/enchanted_item_glint.png",
+    "misc/pumpkinblur.png",
+    "misc/spyglass_scope.png"
   ],
   "bedrock": [
     "font/",


### PR DESCRIPTION
Not sure how many of these you'd want to accept, but for Classic Faithful's purposes these will not be textured at any rate, and as a result shows the percentage when using /missing inaccurately.